### PR TITLE
Implement aligning and distributing items from context menu

### DIFF
--- a/frontend/src/app.scss
+++ b/frontend/src/app.scss
@@ -596,12 +596,17 @@ a {
             @extend .ui-context-menu;
             display: flex;
             font-size: 1rem;
-            margin-top: -5em;
+            margin-top: -3em;
             cursor: pointer;
+            .align {
+                &:not(:last-child) {
+                    margin-right: 2em;
+                }
+            }
             .icon-group {
                 display: inline-block;
-                &:not(:first-child) {
-                    margin-left: 2em;
+                &:not(:last-child) {
+                    margin-right: 2em;
                 }
                 .icon {
                     &:not(:last-child) {
@@ -610,9 +615,6 @@ a {
                 }
             }
             .colors {
-                &:not(:first-child) {
-                    margin-top: 1em;
-                }
                 .color {
                     height: 1em;
                     width: 1em;

--- a/frontend/src/app.scss
+++ b/frontend/src/app.scss
@@ -596,10 +596,23 @@ a {
             @extend .ui-context-menu;
             display: flex;
             font-size: 1rem;
-            height: 2em;
-            margin-top: -2.5em;
+            margin-top: -5em;
             cursor: pointer;
+            .icon-group {
+                display: inline-block;
+                &:not(:first-child) {
+                    margin-left: 2em;
+                }
+                .icon {
+                    &:not(:last-child) {
+                        margin-right: 1em;
+                    }
+                }
+            }
             .colors {
+                &:not(:first-child) {
+                    margin-top: 1em;
+                }
                 .color {
                     height: 1em;
                     width: 1em;
@@ -741,6 +754,38 @@ a {
         @extend .material-icons;
         @include material-icon("pan_tool");
         font-size: 0.9em;
+    }
+    &.align_horizontal_left {
+        @extend .material-icons;
+        @include material-icon("align_horizontal_left");
+    }
+    &.align_horizontal_center {
+        @extend .material-icons;
+        @include material-icon("align_horizontal_center");
+    }
+    &.align_horizontal_right {
+        @extend .material-icons;
+        @include material-icon("align_horizontal_right");
+    }
+    &.align_vertical_top {
+        @extend .material-icons;
+        @include material-icon("align_vertical_top");
+    }
+    &.align_vertical_center {
+        @extend .material-icons;
+        @include material-icon("align_vertical_center");
+    }
+    &.align_vertical_bottom {
+        @extend .material-icons;
+        @include material-icon("align_vertical_bottom");
+    }
+    &.horizontal_distribute {
+        @extend .material-icons;
+        @include material-icon("horizontal_distribute");
+    }
+    &.vertical_distribute {
+        @extend .material-icons;
+        @include material-icon("vertical_distribute");
     }
     &.cursor-arrow {
         background-image: url(img/cursor-arrow.svg);

--- a/frontend/src/board/ContextMenuView.tsx
+++ b/frontend/src/board/ContextMenuView.tsx
@@ -67,11 +67,10 @@ export const ContextMenuView = ({
     function moveFocusedItems(axis: Axis, getCoordinateToSetToItem: GetCoordinate) {
         const b = board.get()
 
-        const numberOfItems = L.view(focusedItems, (items) => items.length).get()
-        const min = L.view(focusedItems, (items) => _.min(items.map((i) => i[axis])))?.get() || 0
-        const max = L.view(focusedItems, (items) => _.max(items.map((i) => i[axis] + getItemSize(i, axis))))?.get() || 0
-        const totalSumOfSizes =
-            L.view(focusedItems, (items) => _.sum(items.map((i) => getItemSize(i, axis), 0)))?.get() || 0
+        const itemsToMove = focusedItems.get()
+        const min = _.min(itemsToMove.map((i) => i[axis])) || 0
+        const max = _.max(itemsToMove.map((i) => i[axis] + getItemSize(i, axis))) || 0
+        const totalSumOfSizes = _.sum(itemsToMove.map((i) => getItemSize(i, axis), 0))
 
         let sumOfPreviousSizes = 0
         const updatedItems = focusedItems
@@ -86,7 +85,7 @@ export const ContextMenuView = ({
                         max,
                         axis,
                         index,
-                        numberOfItems,
+                        itemsToMove.length,
                         sumOfPreviousSizes,
                         totalSumOfSizes,
                     ),

--- a/frontend/src/board/ContextMenuView.tsx
+++ b/frontend/src/board/ContextMenuView.tsx
@@ -1,11 +1,10 @@
 import { h } from "harmaja"
 import * as L from "lonna"
 import _ from "lodash"
-import { Board, Color, findItem, isColoredItem, isTextItem, Note } from "../../../common/src/domain"
+import { Board, Color, findItem, isColoredItem, Item, isTextItem, Note } from "../../../common/src/domain"
 import { Dispatch } from "../store/user-session-store"
 import { NOTE_COLORS } from "./PaletteView"
-import { BoardFocus, getSelectedItems } from "./board-focus"
-import { getItem } from "../../../common/src/domain"
+import { BoardFocus } from "./board-focus"
 
 export const ContextMenuView = ({
     latestNote,
@@ -31,38 +30,78 @@ export const ContextMenuView = ({
         }
     }
 
-    const focusedItems = L.view(focus, board, (f, b) => {
+    const focusedItems = L.view(focus, board, (f) => {
         const itemIds = itemIdsForContextMenu(f)
         return itemIds.flatMap((id) => findItem(board.get())(id) || [])
     })
 
     const focusItem = L.view(focusedItems, (items) => {
         if (items.length === 0) return null
+        const minY = _.min(items.map((i) => i.y)) || 0
+        const maxY = _.max(items.map((i) => i.y + i.height)) || 0
         return {
             x: _.mean(items.map((i) => i.x)),
-            y: _.min(items.map((i) => i.y)),
+            y: minY > 5 ? minY : maxY + 6,
         }
     })
 
-    const widgetCreators = [menuColors(), menuFontSizes()]
+    const widgetCreators = [menuItems(), menuFontSizes()]
     const activeWidgets = L.view(L.combineAsArray(widgetCreators), (arrays) => arrays.flat())
 
-    return L.view(
-        activeWidgets,
-        (ws) => ws.length === 0,
-        (hide) =>
-            hide ? null : (
-                <div
-                    className="context-menu-positioner"
-                    style={L.combineTemplate({
-                        left: L.view(focusItem, (p) => (p ? p.x + "em" : 0)),
-                        top: L.view(focusItem, (p) => (p ? p.y + "em" : 0)),
-                    })}
-                >
-                    <div className="context-menu">{activeWidgets}</div>
-                </div>
-            ),
-    )
+    type Axis = "x" | "y"
+    type GetCoordinate = (
+        item: Item,
+        min: number,
+        max: number,
+        axis: Axis,
+        index: number,
+        numberOfItems: number,
+        sumOfPreviousSizes: number,
+        totalSumOfSizes: number,
+    ) => number
+
+    function getItemSize(item: Item, axis: Axis) {
+        return axis === "x" ? item.width : item.height
+    }
+
+    function moveFocusedItems(axis: Axis, getCoordinateToSetToItem: GetCoordinate) {
+        const b = board.get()
+
+        const numberOfItems = L.view(focusedItems, (items) => items.length).get()
+        const min = L.view(focusedItems, (items) => _.min(items.map((i) => i[axis])))?.get() || 0
+        const max = L.view(focusedItems, (items) => _.max(items.map((i) => i[axis] + getItemSize(i, axis))))?.get() || 0
+        const totalSumOfSizes =
+            L.view(focusedItems, (items) => _.sum(items.map((i) => getItemSize(i, axis), 0)))?.get() || 0
+
+        let sumOfPreviousSizes = 0
+        const updatedItems = focusedItems
+            .get()
+            .sort((item1, item2) => item1[axis] - item2[axis])
+            .map((item, index) => {
+                const newItem = {
+                    ...item,
+                    [axis]: getCoordinateToSetToItem(
+                        item,
+                        min,
+                        max,
+                        axis,
+                        index,
+                        numberOfItems,
+                        sumOfPreviousSizes,
+                        totalSumOfSizes,
+                    ),
+                }
+                sumOfPreviousSizes += getItemSize(item, axis)
+                return newItem
+            })
+        dispatch({ action: "item.update", boardId: b.id, items: updatedItems })
+    }
+
+    const getMinCoordinate: GetCoordinate = (_, min) => min
+
+    const getCenterCoordinate: GetCoordinate = (item, min, max, axis) => (min + max - getItemSize(item, axis)) / 2
+
+    const getMaxCoordinate: GetCoordinate = (item, min, max, axis) => max - getItemSize(item, axis)
 
     function menuFontSizes() {
         const textItems = L.view(focusedItems, (items) => items.filter(isTextItem))
@@ -95,30 +134,94 @@ export const ContextMenuView = ({
         }
     }
 
-    function menuColors() {
+    const getDistributedCoordinate: GetCoordinate = (
+        item,
+        min,
+        max,
+        _,
+        index,
+        numberOfItems,
+        sumOfPreviousSizes,
+        totalSumOfSizes,
+    ) => {
+        const spaceBetweenItems = (max - min - totalSumOfSizes) / (numberOfItems - 1)
+        return min + sumOfPreviousSizes + index * spaceBetweenItems
+    }
+
+    function menuItems() {
+        const numberOfItemsToMove = L.view(focusedItems, (items) => items.length)
         const coloredItems = L.view(focusedItems, (items) => items.filter(isColoredItem))
         const anyColored = L.view(coloredItems, (items) => items.length > 0)
 
-        return L.view(anyColored, (any) =>
-            !any
+        return L.combine(anyColored, numberOfItemsToMove, (anyColored, numberOfItemsToMove) => {
+            const hasItemsToAlign = numberOfItemsToMove > 1
+            const hasItemsToDistribute = numberOfItemsToMove > 2
+            return !(anyColored || hasItemsToAlign || hasItemsToDistribute)
                 ? []
                 : [
-                      <div className="colors">
-                          {NOTE_COLORS.map((color) => {
-                              return (
+                      <div>
+                          {hasItemsToAlign && (
+                              <div className="icon-group">
                                   <span
-                                      className={"color " + color}
-                                      style={{ background: color }}
-                                      onClick={() => setColor(color)}
+                                      className="icon align_horizontal_left"
+                                      onClick={() => moveFocusedItems("x", getMinCoordinate)}
                                   />
-                              )
-                          })}
+                                  <span
+                                      className="icon align_horizontal_center"
+                                      onClick={() => moveFocusedItems("x", getCenterCoordinate)}
+                                  />
+                                  <span
+                                      className="icon align_horizontal_right"
+                                      onClick={() => moveFocusedItems("x", getMaxCoordinate)}
+                                  />
+                              </div>
+                          )}
+                          {hasItemsToAlign && (
+                              <div className="icon-group">
+                                  <span
+                                      className="icon align_vertical_top"
+                                      onClick={() => moveFocusedItems("y", getMinCoordinate)}
+                                  />
+                                  <span
+                                      className="icon align_vertical_center"
+                                      onClick={() => moveFocusedItems("y", getCenterCoordinate)}
+                                  />
+                                  <span
+                                      className="icon align_vertical_bottom"
+                                      onClick={() => moveFocusedItems("y", getMaxCoordinate)}
+                                  />
+                              </div>
+                          )}
+                          {hasItemsToDistribute && (
+                              <div className="icon-group">
+                                  <span
+                                      className="icon horizontal_distribute"
+                                      onClick={() => moveFocusedItems("x", getDistributedCoordinate)}
+                                  />
+                                  <span
+                                      className="icon vertical_distribute"
+                                      onClick={() => moveFocusedItems("y", getDistributedCoordinate)}
+                                  />
+                              </div>
+                          )}
+                          {anyColored && (
+                              <div className="colors">
+                                  {NOTE_COLORS.map((color) => {
+                                      return (
+                                          <span
+                                              className={"color " + color}
+                                              style={{ background: color }}
+                                              onClick={() => setColor(color)}
+                                          />
+                                      )
+                                  })}
+                              </div>
+                          )}
                       </div>,
-                  ],
-        )
+                  ]
+        })
 
         function setColor(color: Color) {
-            const f = focus.get()
             const b = board.get()
 
             // To remember color selection for creating new notes.
@@ -128,4 +231,21 @@ export const ContextMenuView = ({
             dispatch({ action: "item.update", boardId: b.id, items: updated })
         }
     }
+
+    return L.view(
+        activeWidgets,
+        (ws) => ws.length === 0,
+        (hide) =>
+            hide ? null : (
+                <div
+                    className="context-menu-positioner"
+                    style={L.combineTemplate({
+                        left: L.view(focusItem, (p) => (p ? p.x + "em" : 0)),
+                        top: L.view(focusItem, (p) => (p ? p.y + "em" : 0)),
+                    })}
+                >
+                    <div className="context-menu">{activeWidgets}</div>
+                </div>
+            ),
+    )
 }

--- a/frontend/src/board/ContextMenuView.tsx
+++ b/frontend/src/board/ContextMenuView.tsx
@@ -41,7 +41,7 @@ export const ContextMenuView = ({
         const maxY = _.max(items.map((i) => i.y + i.height)) || 0
         return {
             x: _.mean(items.map((i) => i.x)),
-            y: minY > 5 ? minY : maxY + 6,
+            y: minY > 3 ? minY : maxY + 4,
         }
     })
 


### PR DESCRIPTION
I put my changes in a branch because I'm unsure about my usage of `L.view` and `Property`.

Stuff in ContextMenuView.moveFocusedItems isn't probably very idiomatic. I'm suspecting there is a smarter way to avoid those `?.get() || 0`s.